### PR TITLE
Partial fix for costume parsing

### DIFF
--- a/src/containers/CostumeCanvasContainer.js
+++ b/src/containers/CostumeCanvasContainer.js
@@ -37,7 +37,7 @@ const CostumeCanvasContainer = ({
 
   const id = costumeIdLookupTable[cIndex + 1];
   const desc = sprdesc[id];
-  // this was 3 bytes per sprite in the data but has been parsed to 1 byte
+  // this was 3 bytes per sprite in the data but has been parsed down to 1 byte
   const offset = sproffs[desc + frame] / 3;
   const spritesNum = sprlens[desc + frame];
   const palette = sprpals.palette;
@@ -55,7 +55,7 @@ const CostumeCanvasContainer = ({
   let bottom = 0;
 
   for (let i = 0; i < spritesNum; i++) {
-    const { x, y } = sprdata[offset + i] || {};
+    const { x, y } = sprdata[offset + i];
 
     left = Math.min(left, x);
     right = Math.max(right, x + 8);
@@ -145,7 +145,7 @@ const draw = (
   ctx.clearRect(0, 0, width, height);
 
   for (let i = 0; i < spritesNum; i++) {
-    const { x, y, tile, flip, paletteId } = sprdata[offset + i] || {};
+    const { x, y, tile, flip, paletteId } = sprdata[offset + i];
     // console.log(sprdata[i]);
 
     const pal = getPalette([

--- a/src/containers/CostumeCanvasContainer.js
+++ b/src/containers/CostumeCanvasContainer.js
@@ -22,6 +22,7 @@ const darkpalette = [
 ];
 
 const CostumeCanvasContainer = ({
+  cIndex,
   frame,
   gfx,
   sprdesc,
@@ -34,9 +35,10 @@ const CostumeCanvasContainer = ({
   const canvasRef = useRef(null);
   const [isComputing, setIsComputing] = useState(true);
 
-  const id = costumeIdLookupTable[frame];
+  const id = costumeIdLookupTable[cIndex + 1];
   const desc = sprdesc[id];
-  const offset = sproffs[frame];
+  // this was 3 bytes per sprite in the data but has been parsed to 1 byte
+  const offset = sproffs[desc + frame] / 3;
   const spritesNum = sprlens[desc + frame];
   const palette = sprpals.palette;
 
@@ -53,7 +55,7 @@ const CostumeCanvasContainer = ({
   let bottom = 0;
 
   for (let i = 0; i < spritesNum; i++) {
-    const { x, y } = sprdata[i];
+    const { x, y } = sprdata[offset + i] || {};
 
     left = Math.min(left, x);
     right = Math.max(right, x + 8);
@@ -143,7 +145,7 @@ const draw = (
   ctx.clearRect(0, 0, width, height);
 
   for (let i = 0; i < spritesNum; i++) {
-    const { x, y, tile, flip, paletteId } = sprdata[offset + i];
+    const { x, y, tile, flip, paletteId } = sprdata[offset + i] || {};
     // console.log(sprdata[i]);
 
     const pal = getPalette([

--- a/src/containers/CostumesContainer.js
+++ b/src/containers/CostumesContainer.js
@@ -5,6 +5,7 @@ import Main from '../components/Main';
 import MainHeader from '../components/MainHeader';
 import ResourceMetadata from '../components/ResourceMetadata';
 import CostumeCanvasContainer from './CostumeCanvasContainer';
+import { hex } from '../lib/utils';
 
 const CostumesContainer = ({
   costumegfx,
@@ -21,15 +22,15 @@ const CostumesContainer = ({
   const costume =
     costumes.find(({ metadata }) => metadata.id === currentId) || null;
 
-  // console.log('costumegfx', costumegfx);
+  //console.log('costumegfx', costumegfx);
   console.log('costumes', costumes);
-  console.log('sprpals', sprpals);
-  console.log('sprdesc', sprdesc);
-  console.log('sproffs', sproffs);
-  console.log('sprlens', sprlens);
-  console.log('sprdata', sprdata);
+  //console.log('sprpals', sprpals);
+  console.log('sprdesc', sprdesc[0].sprdesc.map((v) => hex(v, 4)));
+  console.log('sproffs', sproffs[0].sproffs.map((v) => hex(v, 4)));
+  console.log('sprlens', sprlens[0].sprlens);
+  console.log('sprdata', sprdata[0].sprdata);
 
-  console.log('costume', costume);
+  //console.log('costume', costume);
 
   if (!costume) {
     return null;
@@ -54,9 +55,10 @@ const CostumesContainer = ({
             <div className="flex flex-row gap-4">
               {costume.map((frame, j) => (
                 <div key={j}>
-                  <h3>{`Frame ${frame}`}</h3>
+                  <h3>{`Frame ${j}`}</h3>
                   <CostumeCanvasContainer
-                    frame={frame}
+                    cIndex={i}
+                    frame={j}
                     gfx={costumegfx[0]}
                     sprdesc={sprdesc[0].sprdesc}
                     sproffs={sproffs[0].sproffs}

--- a/src/containers/CostumesContainer.js
+++ b/src/containers/CostumesContainer.js
@@ -46,16 +46,16 @@ const CostumesContainer = ({
       </PrimaryColumn>
 
       <Main>
-        <MainHeader title={`Costume ${currentId}`}>
+        <MainHeader title={`Costumes`}>
           <ResourceMetadata metadata={costume.metadata} />
         </MainHeader>
         {costume.costumes.map((costume, i) => (
           <div key={i}>
-            <h2>{`Costume ${i}`}</h2>
+            <h2>{`Costume ${i+1}`}</h2>
             <div className="flex flex-row gap-4">
               {costume.map((frame, j) => (
                 <div key={j}>
-                  <h3>{`Frame ${j}`}</h3>
+                  <h3 class="text-xs">{`Frame ${j}`}</h3>
                   <CostumeCanvasContainer
                     cIndex={i}
                     frame={j}
@@ -65,7 +65,7 @@ const CostumesContainer = ({
                     sprlens={sprlens[0].sprlens}
                     sprdata={sprdata[0].sprdata}
                     sprpals={sprpals[0]}
-                    zoom={4}
+                    zoom={2}
                   />
                 </div>
               ))}


### PR DESCRIPTION
This mostly fixes the costume parsing. Now it just needs to be fixed to loop through the correct number of frames for each costume. Note that the `costume.costumes` object really isn't providing anything at the moment other than a few indices (`i` and `j`) so it can be rethought. Maybe access to `sprdesc`, `sproffs`, `sprlens`, and `sprdata` should happen at that level instead.